### PR TITLE
Adding a .gitignore for install.*.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+install.*.log


### PR DESCRIPTION
Small change for an excellent project - worked first time on Mac OS X 10.10 - unlike everything else like this I've ever tried. Brilliant!

Any chance of supporting clang 3.7 when it comes out?