### PR TITLE
Fix build/test on macOS Mojave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 install.*.log
+a.out

--- a/install-clang
+++ b/install-clang
@@ -17,7 +17,7 @@ elif [ "$OS" == "FreeBSD" ]; then
 elif [ "$OS" == "Darwin" ]; then
     triple=""
     addl_ldflags=""
-    addl_cmake="-DLLDB_CODESIGN_IDENTITY="
+    addl_cmake="-DCMAKE_OSX_ARCHITECTURES=x86_64 -DDARWIN_iossim_ARCHS=x86_64 -DLLDB_CODESIGN_IDENTITY="
 
 else
     echo "OS $OS not supported by this script."

--- a/testit
+++ b/testit
@@ -5,5 +5,11 @@ if [ $# != 1 ]; then
     exit 1
 fi
 
-$1/bin/clang++ --std=c++17 --stdlib=libc++ test.cc -o a.out -lc++experimental  && ./a.out
+OS="$(uname)"
+
+if [ "$OS" == "Darwin" ]; then
+  sysroot="-isysroot $(xcodebuild -version -sdk macosx Path)"
+fi
+
+$1/bin/clang++ $sysroot --std=c++17 --stdlib=libc++ test.cc -o a.out -lc++experimental  && ./a.out
 #rm -f a.out


### PR DESCRIPTION
* Explicitly set just x86_64 architecture for OSX and iOS
  simulator.  Else the later would automatically include i386 and cause
  linking errors during the build.

* Starting in 10.14, system headers are no longer installed to
  /usr/include by Xcode Command Line Tools (`xcode-select --install`), so
  the testit script now explicitly passes an -isysroot flag.  Not sure
  if it's appropriate to actually modify the clang that gets built by
  install-clang to automatically include this flag (first hunch is
  "no"), but at least Homebrew's clang is also taking the approach of
  making people explicitly set the desired sysroot/SDK themselves so
  just following that lead:

  https://github.com/Homebrew/homebrew-core/issues/32765

  https://github.com/Homebrew/brew/pull/4334